### PR TITLE
Resolve multiple compiler warnings

### DIFF
--- a/src/main/java/com/radixdlt/atommodel/message/MessageParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/message/MessageParticle.java
@@ -62,7 +62,8 @@ public final class MessageParticle extends Particle {
 	@DsonOutput(DsonOutput.Output.ALL)
 	private long nonce;
 
-	private MessageParticle() {
+	MessageParticle() {
+		// Serializer only
 		super(ImmutableSet.of());
 	}
 

--- a/src/main/java/com/radixdlt/atommodel/routines/CreateCombinedTransitionRoutine.java
+++ b/src/main/java/com/radixdlt/atommodel/routines/CreateCombinedTransitionRoutine.java
@@ -76,6 +76,7 @@ public final class CreateCombinedTransitionRoutine<I extends Particle, O extends
 		this.inputWitnessValidator = inputWitnessValidator;
 	}
 
+	@Override
 	public void main(RoutineCalls calls) {
 		calls.createTransition(
 			new TransitionToken<>(inputClass, TypeToken.of(VoidUsedData.class), outputClass0, TypeToken.of(VoidUsedData.class)),

--- a/src/main/java/com/radixdlt/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
@@ -62,7 +62,8 @@ public final class MutableSupplyTokenDefinitionParticle extends Particle {
 
 	private Map<TokenTransition, TokenPermission> tokenPermissions;
 
-	private MutableSupplyTokenDefinitionParticle() {
+	MutableSupplyTokenDefinitionParticle() {
+		// Serializer only
 		super();
 	}
 

--- a/src/main/java/com/radixdlt/atommodel/tokens/UnallocatedTokensParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/UnallocatedTokensParticle.java
@@ -54,7 +54,8 @@ public class UnallocatedTokensParticle extends Particle {
 
 	private Map<TokenTransition, TokenPermission> tokenPermissions;
 
-	private UnallocatedTokensParticle() {
+	UnallocatedTokensParticle() {
+		// Serializer only
 		super();
 	}
 

--- a/src/main/java/com/radixdlt/atomos/RRIParticle.java
+++ b/src/main/java/com/radixdlt/atomos/RRIParticle.java
@@ -32,7 +32,8 @@ public final class RRIParticle extends Particle {
 	@DsonOutput(DsonOutput.Output.ALL)
 	private long nonce;
 
-	private RRIParticle() {
+	RRIParticle() {
+		// Serializer only
 	}
 
 	public RRIParticle(RRI rri) {

--- a/src/test/java/com/radixdlt/atommodel/routines/CreateFungibleTransitionRoutineTest.java
+++ b/src/test/java/com/radixdlt/atommodel/routines/CreateFungibleTransitionRoutineTest.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class CreateFungibleTransitionRoutineTest {
+
 	private static class Fungible extends Particle {
 		private final UInt256 amount;
 		Fungible(UInt256 amount) {
@@ -47,6 +48,10 @@ public class CreateFungibleTransitionRoutineTest {
 		}
 	}
 
+	interface WitnessValidatorFungible extends WitnessValidator<Fungible> {
+		// Empty
+	}
+
 	@Test
 	public void equalsContract() {
 		EqualsVerifier.forClass(CreateFungibleTransitionRoutine.UsedAmount.class)
@@ -58,7 +63,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, UsedAmount, Fungible, VoidUsedData> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure1();
 
 		assertThatThrownBy(() -> procedure.inputUsedCompute().compute(
@@ -81,7 +86,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, UsedAmount> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure2();
 
 		assertThatThrownBy(() -> procedure.inputUsedCompute().compute(
@@ -104,7 +109,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, VoidUsedData> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure0();
 
 		assertThat(procedure.inputUsedCompute().compute(
@@ -128,7 +133,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, VoidUsedData> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure0();
 
 
@@ -152,7 +157,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, VoidUsedData> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure0();
 
 		assertThat(procedure.inputUsedCompute().compute(
@@ -175,7 +180,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, VoidUsedData> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure0();
 
 		assertThat(procedure.inputUsedCompute().compute(
@@ -198,7 +203,7 @@ public class CreateFungibleTransitionRoutineTest {
 		TransitionProcedure<Fungible, VoidUsedData, Fungible, UsedAmount> procedure = new CreateFungibleTransitionRoutine<>(
 			Fungible.class, Fungible.class, Fungible::getAmount, Fungible::getAmount,
 			(a, b) -> Result.success(),
-			mock(WitnessValidator.class)
+			mock(WitnessValidatorFungible.class)
 		).getProcedure2();
 
 		assertThat(procedure.inputUsedCompute().compute(

--- a/src/test/java/com/radixdlt/atomos/CMAtomOSTest.java
+++ b/src/test/java/com/radixdlt/atomos/CMAtomOSTest.java
@@ -49,16 +49,25 @@ public class CMAtomOSTest {
 	}
 
 	private abstract static class TestParticle0 extends Particle {
+		// Empty
 	}
 
 	private abstract static class TestParticle1 extends Particle {
+		// Empty
 	}
 
+	interface TransitionProcedureTestParticle00 extends TransitionProcedure<TestParticle0, VoidUsedData, TestParticle0, VoidUsedData> {
+		// Empty
+	}
+
+	interface TransitionProcedureTestParticle10 extends TransitionProcedure<TestParticle1, VoidUsedData, TestParticle0, VoidUsedData> {
+		// Empty
+	}
 
 	@Test
 	public void when_adding_procedure_on_particle_registered_in_another_scrypt__exception_is_thrown() {
 		CMAtomOS os = new CMAtomOS();
-		TransitionProcedure<TestParticle0, VoidUsedData, TestParticle0, VoidUsedData> procedure = mock(TransitionProcedure.class);
+		TransitionProcedure<TestParticle0, VoidUsedData, TestParticle0, VoidUsedData> procedure = mock(TransitionProcedureTestParticle00.class);
 		os.load(syscalls -> {
 			syscalls.registerParticle(TestParticle0.class, (TestParticle0 p) -> mock(RadixAddress.class), t -> Result.success());
 			syscalls.createTransition(
@@ -71,7 +80,7 @@ public class CMAtomOSTest {
 				procedure
 			);
 		});
-		TransitionProcedure<TestParticle1, VoidUsedData, TestParticle0, VoidUsedData> procedure0 = mock(TransitionProcedure.class);
+		TransitionProcedure<TestParticle1, VoidUsedData, TestParticle0, VoidUsedData> procedure0 = mock(TransitionProcedureTestParticle10.class);
 		assertThatThrownBy(() ->
 			os.load(syscalls -> {
 				syscalls.registerParticle(TestParticle1.class, (TestParticle1 p) -> mock(RadixAddress.class), t -> Result.success());

--- a/src/test/java/com/radixdlt/common/EUIDTest.java
+++ b/src/test/java/com/radixdlt/common/EUIDTest.java
@@ -20,13 +20,12 @@ package com.radixdlt.common;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.google.common.base.Strings;
 import com.radixdlt.utils.Bytes;
 import com.radixdlt.utils.UInt128;
@@ -61,14 +60,12 @@ public class EUIDTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void verify_that_exception_is_thrown_when_calling_constructor_with_too_short_hexstring() {
-		new EUID("deadbeef");
-		fail();
+		assertNull(new EUID("deadbeef"));
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void verify_that_exception_is_thrown_when_calling_constructor_with_empty_byte_array() {
-		new EUID(new byte[0]);
-		fail();
+		assertNull(new EUID(new byte[0]));
 	}
 
 	@Test

--- a/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
+++ b/src/test/java/com/radixdlt/crypto/ECKeyPairTest.java
@@ -21,10 +21,7 @@ import com.radixdlt.TestSetupUtils;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.nio.charset.StandardCharsets;
 
 public class ECKeyPairTest {
@@ -32,9 +29,6 @@ public class ECKeyPairTest {
 	public static void beforeClass() {
 		TestSetupUtils.installBouncyCastleProvider();
 	}
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void equalsContract() {

--- a/src/test/java/com/radixdlt/crypto/HashTest.java
+++ b/src/test/java/com/radixdlt/crypto/HashTest.java
@@ -18,12 +18,11 @@
 package com.radixdlt.crypto;
 
 import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.assertNull;
 import com.google.common.base.Strings;
 import com.radixdlt.TestSetupUtils;
 import com.radixdlt.utils.Bytes;
@@ -54,8 +53,7 @@ public class HashTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void verify_that_an_error_is_thrown_for_too_short_hex_string_constructor() {
-		new Hash("deadbeef");
-		fail();
+		assertNull(new Hash("deadbeef"));
 	}
 
 	@Test

--- a/src/test/java/com/radixdlt/crypto/RadixKeyStoreTest.java
+++ b/src/test/java/com/radixdlt/crypto/RadixKeyStoreTest.java
@@ -43,6 +43,7 @@ import com.radixdlt.TestSetupUtils;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.assertj.core.api.Assertions.*;
 
 public class RadixKeyStoreTest {

--- a/src/test/java/com/radixdlt/crypto/SignaturesTest.java
+++ b/src/test/java/com/radixdlt/crypto/SignaturesTest.java
@@ -1,7 +1,6 @@
 package com.radixdlt.crypto;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -126,8 +125,8 @@ public class SignaturesTest {
         Signatures signatures = DefaultSignatures.single(publicKey(), dummySignature);
         String tostring = signatures.toString();
 
-        Assert.assertThat(tostring, containsString(ECDSASignature.class.getSimpleName()));
-        Assert.assertThat(tostring, containsString(dummySignature.toString()));
+        assertThat(tostring, containsString(ECDSASignature.class.getSimpleName()));
+        assertThat(tostring, containsString(dummySignature.toString()));
     }
 
     private void test_that_we_can_bulk_verify_signatures(

--- a/src/test/java/com/radixdlt/serialization/ECDSASignatureSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/ECDSASignatureSerializationTest.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.serialization;
 
 import com.radixdlt.TestSetupUtils;

--- a/src/test/java/com/radixdlt/serialization/ECDSASignaturesSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/ECDSASignaturesSerializationTest.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.serialization;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.serialization;
 
 import com.radixdlt.TestSetupUtils;

--- a/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/RRIParticleSerializationTest.java
@@ -1,0 +1,62 @@
+package com.radixdlt.serialization;
+
+import com.radixdlt.TestSetupUtils;
+import com.radixdlt.atomos.RRI;
+import com.radixdlt.atomos.RRIParticle;
+import com.radixdlt.atomos.RadixAddress;
+import com.radixdlt.crypto.CryptoException;
+import com.radixdlt.crypto.ECKeyPair;
+
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * JSON Serialization round trip of {@link RRIParticle} object.
+ */
+public class RRIParticleSerializationTest extends SerializeObjectEngine<RRIParticle> {
+	private static final String NAME = "TEST";
+	private static final ECKeyPair keyPair;
+	private static final RadixAddress address;
+	private static final RRI rri;
+
+	static {
+        try {
+        	keyPair = new ECKeyPair();
+        	address = new RadixAddress((byte) 123, keyPair.getPublicKey());
+        	rri = RRI.of(address, NAME);
+    	} catch (CryptoException ex) {
+    		throw new IllegalStateException("Error while creating RRIParticle", ex);
+    	}
+	}
+
+    public RRIParticleSerializationTest() {
+        super(RRIParticle.class, RRIParticleSerializationTest::get);
+    }
+
+    @BeforeClass
+    public static void startRRIParticleSerializationTest() {
+        TestSetupUtils.installBouncyCastleProvider();
+    }
+
+    @Test
+    public void testGetters() {
+    	RRIParticle p = get();
+    	assertEquals(rri, p.getRri());
+    	assertEquals(0L, p.getNonce());
+    }
+
+    @Test
+    public void testToString() {
+    	String s = get().toString();
+    	assertThat(s, containsString(RRIParticle.class.getSimpleName()));
+    	assertThat(s, containsString(rri.toString()));
+    }
+
+    private static RRIParticle get() {
+    	return new RRIParticle(rri);
+    }
+}

--- a/src/test/java/com/radixdlt/serialization/SerializationTestUtilsEngine.java
+++ b/src/test/java/com/radixdlt/serialization/SerializationTestUtilsEngine.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.serialization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/test/java/com/radixdlt/serialization/SerializeObjectEngine.java
+++ b/src/test/java/com/radixdlt/serialization/SerializeObjectEngine.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package com.radixdlt.serialization;
 
 import org.junit.Test;

--- a/src/test/java/com/radixdlt/utils/UInt128Test.java
+++ b/src/test/java/com/radixdlt/utils/UInt128Test.java
@@ -20,10 +20,10 @@ package com.radixdlt.utils;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.math.BigIntegerMath;

--- a/src/test/java/com/radixdlt/utils/UInt256Test.java
+++ b/src/test/java/com/radixdlt/utils/UInt256Test.java
@@ -20,10 +20,10 @@ package com.radixdlt.utils;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/com/radixdlt/utils/UInt384Test.java
+++ b/src/test/java/com/radixdlt/utils/UInt384Test.java
@@ -20,10 +20,10 @@ package com.radixdlt.utils;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
Reduced compiler warnings from 109 to 35.

Remaining warnings are around `TransitionToken` and related uses in constraint machine and scrypt.  Have not addressed these yet, as there appears to be some typing issues that need to be resolved as part of a wider discussion.