### PR TITLE
Basic delegated staking

### DIFF
--- a/src/main/java/com/radixdlt/atommodel/tokens/StakedTokensParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/StakedTokensParticle.java
@@ -1,0 +1,167 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.atommodel.tokens;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition;
+import com.radixdlt.constraintmachine.Particle;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.serialization.DsonOutput;
+import com.radixdlt.serialization.DsonOutput.Output;
+import com.radixdlt.serialization.SerializerId2;
+import com.radixdlt.utils.UInt256;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ *  A particle which represents an amount of staked fungible tokens
+ *  owned by some key owner, stored in an account and staked to a delegate address.
+ */
+@SerializerId2("radix.particles.staked_tokens")
+public final class StakedTokensParticle extends Particle {
+	@JsonProperty("delegateAddress")
+	@DsonOutput(Output.ALL)
+	private RadixAddress delegateAddress;
+
+	@JsonProperty("address")
+	@DsonOutput(Output.ALL)
+	private RadixAddress address;
+
+	@JsonProperty("tokenDefinitionReference")
+	@DsonOutput(Output.ALL)
+	private RRI tokenDefinitionReference;
+
+	@JsonProperty("granularity")
+	@DsonOutput(Output.ALL)
+	private UInt256 granularity;
+
+	@JsonProperty("planck")
+	@DsonOutput(Output.ALL)
+	private long planck;
+
+	@JsonProperty("nonce")
+	@DsonOutput(Output.ALL)
+	private long nonce;
+
+	@JsonProperty("amount")
+	@DsonOutput(Output.ALL)
+	private UInt256 amount;
+
+	private Map<TokenTransition, TokenPermission> tokenPermissions;
+
+	public StakedTokensParticle() {
+		super();
+		this.tokenPermissions = ImmutableMap.of();
+	}
+
+	public StakedTokensParticle(
+		RadixAddress delegateAddress,
+		RadixAddress address,
+		UInt256 amount,
+		UInt256 granularity,
+		RRI tokenDefinitionReference,
+		long planck,
+		Map<TokenTransition, TokenPermission> tokenPermissions
+	) {
+		super(address.euid());
+
+		this.delegateAddress = Objects.requireNonNull(delegateAddress);
+		this.address = Objects.requireNonNull(address);
+		this.granularity = Objects.requireNonNull(granularity);
+		this.tokenDefinitionReference = Objects.requireNonNull(tokenDefinitionReference);
+		this.planck = planck;
+		this.nonce = System.nanoTime();
+		this.amount = Objects.requireNonNull(amount);
+		this.tokenPermissions = ImmutableMap.copyOf(tokenPermissions);
+	}
+
+	public RadixAddress getDelegateAddress() {
+		return delegateAddress;
+	}
+
+	public RadixAddress getAddress() {
+		return this.address;
+	}
+
+	public RRI getTokDefRef() {
+		return this.tokenDefinitionReference;
+	}
+
+	public UInt256 getGranularity() {
+		return this.granularity;
+	}
+
+	public Map<TokenTransition, TokenPermission> getTokenPermissions() {
+		return tokenPermissions;
+	}
+
+	public TokenPermission getTokenPermission(TokenTransition transition) {
+		return tokenPermissions.get(transition);
+	}
+
+	@JsonProperty("permissions")
+	@DsonOutput(Output.ALL)
+	private Map<String, String> getJsonPermissions() {
+		return this.tokenPermissions.entrySet().stream()
+			.collect(Collectors.toMap(e -> e.getKey().name().toLowerCase(), e -> e.getValue().name().toLowerCase()));
+	}
+
+	@JsonProperty("permissions")
+	private void setJsonPermissions(Map<String, String> permissions) {
+		if (permissions != null) {
+			this.tokenPermissions = permissions.entrySet().stream()
+				.collect(
+					Collectors.toMap(
+						e -> TokenTransition.valueOf(e.getKey().toUpperCase()),
+						e -> TokenPermission.valueOf(e.getValue().toUpperCase())
+					)
+				);
+		} else {
+			throw new IllegalArgumentException("Permissions cannot be null.");
+		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s[%s:%s:%s:%s:%s:%s:%s]",
+			getClass().getSimpleName(),
+			String.valueOf(tokenDefinitionReference),
+			String.valueOf(amount),
+			String.valueOf(granularity),
+			String.valueOf(address),
+			String.valueOf(delegateAddress),
+			planck,
+			nonce);
+	}
+
+	public UInt256 getAmount() {
+		return this.amount;
+	}
+
+	public long getPlanck() {
+		return this.planck;
+	}
+
+	public long getNonce() {
+		return this.nonce;
+	}
+}

--- a/src/main/java/com/radixdlt/atommodel/tokens/StakedTokensParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/StakedTokensParticle.java
@@ -144,13 +144,14 @@ public final class StakedTokensParticle extends Particle {
 	public String toString() {
 		return String.format("%s[%s:%s:%s:%s:%s:%s:%s]",
 			getClass().getSimpleName(),
-			String.valueOf(tokenDefinitionReference),
-			String.valueOf(amount),
-			String.valueOf(granularity),
-			String.valueOf(address),
-			String.valueOf(delegateAddress),
+			tokenDefinitionReference,
+			amount,
+			granularity,
+			address,
+			delegateAddress,
 			planck,
-			nonce);
+			nonce
+		);
 	}
 
 	public UInt256 getAmount() {

--- a/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
@@ -99,6 +99,26 @@ public final class TokenDefinitionUtils {
 		return Result.success();
 	}
 
+	public static Result staticCheck(StakedTokensParticle stakedParticle) {
+		if (stakedParticle.getDelegateAddress() == null) {
+			return Result.error("delegateAddress must not be null");
+		}
+		if (stakedParticle.getAmount() == null) {
+			return Result.error("amount must not be null");
+		}
+		if (stakedParticle.getAmount().isZero()) {
+			return Result.error("amount must not be zero");
+		}
+		if (stakedParticle.getGranularity() == null) {
+			return Result.error("granularity must not be null");
+		}
+		if (stakedParticle.getGranularity().isZero() || !stakedParticle.getAmount().remainder(stakedParticle.getGranularity()).isZero()) {
+			return Result.error("amount " + stakedParticle.getAmount() + " does not fit granularity " + stakedParticle.getGranularity());
+		}
+
+		return Result.success();
+	}
+
 	public static Result staticCheck(TransferrableTokensParticle tokensParticle) {
 		if (tokensParticle.getAmount() == null) {
 			return Result.error("amount must not be null");

--- a/src/main/java/com/radixdlt/atommodel/tokens/TokensConstraintScrypt.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/TokensConstraintScrypt.java
@@ -37,6 +37,13 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 
 	@Override
 	public void main(SysCalls os) {
+		registerParticles(os);
+		defineTokenCreation(os);
+		defineMintTransferBurn(os);
+		defineStaking(os);
+	}
+
+	private void registerParticles(SysCalls os) {
 		os.registerParticle(
 			MutableSupplyTokenDefinitionParticle.class,
 			ParticleDefinition.<MutableSupplyTokenDefinitionParticle>builder()
@@ -81,7 +88,9 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				.rriMapper(StakedTokensParticle::getTokDefRef)
 				.build()
 		);
+	}
 
+	private void defineTokenCreation(SysCalls os) {
 		// Require Token Definition to be created with unallocated tokens of max supply
 		os.createTransitionFromRRICombined(
 			MutableSupplyTokenDefinitionParticle.class,
@@ -136,7 +145,9 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 			(in, meta) -> meta.isSignedBy(in.getTokDefRef().getAddress().getPublicKey())
 				? WitnessValidatorResult.success() : WitnessValidatorResult.error("Permission not allowed.")
 		));
+	}
 
+	private void defineMintTransferBurn(SysCalls os) {
 		// Mint
 		os.executeRoutine(new CreateFungibleTransitionRoutine<>(
 			UnallocatedTokensParticle.class,
@@ -191,7 +202,9 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 			(in, meta) -> in.getTokenPermission(TokenTransition.BURN).check(in.getTokDefRef(), meta).isSuccess()
 				? WitnessValidatorResult.success() : WitnessValidatorResult.error("Permission not allowed.")
 		));
+	}
 
+	private void defineStaking(SysCalls os) {
 		// Staking
 		os.executeRoutine(new CreateFungibleTransitionRoutine<>(
 			TransferrableTokensParticle.class,

--- a/src/main/java/com/radixdlt/atommodel/tokens/TokensConstraintScrypt.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/TokensConstraintScrypt.java
@@ -17,13 +17,17 @@
 
 package com.radixdlt.atommodel.tokens;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition;
 import com.radixdlt.atomos.ParticleDefinition;
 import com.radixdlt.atomos.SysCalls;
 import com.radixdlt.atomos.ConstraintScrypt;
 import com.radixdlt.atomos.Result;
 import com.radixdlt.atommodel.routines.CreateFungibleTransitionRoutine;
+import com.radixdlt.constraintmachine.WitnessData;
 import com.radixdlt.constraintmachine.WitnessValidator.WitnessValidatorResult;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.utils.UInt256;
 
 import java.util.Objects;
@@ -95,37 +99,13 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 		os.createTransitionFromRRICombined(
 			MutableSupplyTokenDefinitionParticle.class,
 			UnallocatedTokensParticle.class,
-			(tokDef, unallocated) -> {
-				if (!Objects.equals(unallocated.getGranularity(), tokDef.getGranularity())) {
-					return Result.error("Granularities not equal.");
-				}
-				if (!Objects.equals(unallocated.getTokenPermissions(), tokDef.getTokenPermissions())) {
-					return Result.error("Permissions not equal.");
-				}
-				if (!unallocated.getAmount().equals(UInt256.MAX_VALUE)) {
-					return Result.error("Unallocated amount must be UInt256.MAX_VALUE but was " + unallocated.getAmount());
-				}
-
-				return Result.success();
-			}
+			TokensConstraintScrypt::checkCreateUnallocated
 		);
 
 		os.createTransitionFromRRICombined(
 			FixedSupplyTokenDefinitionParticle.class,
 			TransferrableTokensParticle.class,
-			(tokDef, transferrable) -> {
-				if (!Objects.equals(tokDef.getGranularity(), transferrable.getGranularity())) {
-					return Result.error("Granularities not equal.");
-				}
-				if (!Objects.equals(tokDef.getSupply(), transferrable.getAmount())) {
-					return Result.error("Supply and amount are not equal.");
-				}
-				if (!transferrable.getTokenPermissions().isEmpty()) {
-					return Result.error("Transferrable tokens of a fixed supply token must be empty.");
-				}
-
-				return Result.success();
-			}
+			TokensConstraintScrypt::checkCreateTransferrable
 		);
 
 		// Unallocated movement
@@ -162,8 +142,7 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				TransferrableTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> in.getTokenPermission(TokenTransition.MINT).check(in.getTokDefRef(), meta).isSuccess()
-				? WitnessValidatorResult.success() : WitnessValidatorResult.error("Permission not allowed.")
+			(in, meta) -> checkTokenActionAllowed(meta, in.getTokenPermission(TokenTransition.MINT), in.getTokDefRef())
 		));
 
 		// Transfers
@@ -180,9 +159,7 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				TransferrableTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> meta.isSignedBy(in.getAddress().getPublicKey())
-				? WitnessValidatorResult.success()
-				: WitnessValidatorResult.error(String.format("Not signed by: %s", in.getAddress().getPublicKey()))
+			(in, meta) -> checkSignedBy(meta, in.getAddress())
 		));
 
 		// Burns
@@ -199,8 +176,7 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				UnallocatedTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> in.getTokenPermission(TokenTransition.BURN).check(in.getTokDefRef(), meta).isSuccess()
-				? WitnessValidatorResult.success() : WitnessValidatorResult.error("Permission not allowed.")
+			(in, meta) -> checkTokenActionAllowed(meta, in.getTokenPermission(TokenTransition.BURN), in.getTokDefRef())
 		));
 	}
 
@@ -219,9 +195,7 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				StakedTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> meta.isSignedBy(in.getAddress().getPublicKey())
-				? WitnessValidatorResult.success()
-				: WitnessValidatorResult.error(String.format("Not signed by: %s", in.getAddress().getPublicKey()))
+			(in, meta) -> checkSignedBy(meta, in.getAddress())
 		));
 
 		// Re-staking to a different delegate
@@ -238,9 +212,7 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				StakedTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> meta.isSignedBy(in.getAddress().getPublicKey())
-				? WitnessValidatorResult.success()
-				: WitnessValidatorResult.error(String.format("Not signed by: %s", in.getAddress().getPublicKey()))
+			(in, meta) -> checkSignedBy(meta, in.getAddress())
 		));
 
 		// Unstaking
@@ -257,10 +229,51 @@ public class TokensConstraintScrypt implements ConstraintScrypt {
 				TransferrableTokensParticle::getTokenPermissions,
 				"Permissions not equal."
 			),
-			(in, meta) -> meta.isSignedBy(in.getAddress().getPublicKey())
-				? WitnessValidatorResult.success()
-				: WitnessValidatorResult.error(String.format("Not signed by: %s", in.getAddress().getPublicKey()))
+			(in, meta) -> checkSignedBy(meta, in.getAddress())
 		));
+	}
+
+	@VisibleForTesting
+	static Result checkCreateTransferrable(FixedSupplyTokenDefinitionParticle tokDef, TransferrableTokensParticle transferrable) {
+		if (!Objects.equals(tokDef.getGranularity(), transferrable.getGranularity())) {
+			return Result.error("Granularities not equal.");
+		}
+		if (!Objects.equals(tokDef.getSupply(), transferrable.getAmount())) {
+			return Result.error("Supply and amount are not equal.");
+		}
+		if (!transferrable.getTokenPermissions().isEmpty()) {
+			return Result.error("Transferrable tokens of a fixed supply token must be empty.");
+		}
+
+		return Result.success();
+	}
+
+	@VisibleForTesting
+	static Result checkCreateUnallocated(MutableSupplyTokenDefinitionParticle tokDef, UnallocatedTokensParticle unallocated) {
+		if (!Objects.equals(unallocated.getGranularity(), tokDef.getGranularity())) {
+			return Result.error("Granularities not equal.");
+		}
+		if (!Objects.equals(unallocated.getTokenPermissions(), tokDef.getTokenPermissions())) {
+			return Result.error("Permissions not equal.");
+		}
+		if (!unallocated.getAmount().equals(UInt256.MAX_VALUE)) {
+			return Result.error("Unallocated amount must be UInt256.MAX_VALUE but was " + unallocated.getAmount());
+		}
+
+		return Result.success();
+	}
+
+	@VisibleForTesting
+	static WitnessValidatorResult checkTokenActionAllowed(WitnessData meta, TokenPermission tokenPermission, RRI tokDefRef) {
+		return tokenPermission.check(tokDefRef, meta).isSuccess()
+			? WitnessValidatorResult.success() : WitnessValidatorResult.error("Permission not allowed.");
+	}
+
+	@VisibleForTesting
+	static WitnessValidatorResult checkSignedBy(WitnessData meta, RadixAddress address) {
+		return meta.isSignedBy(address.getPublicKey())
+			? WitnessValidatorResult.success()
+			: WitnessValidatorResult.error(String.format("Not signed by: %s", address.getPublicKey()));
 	}
 
 	private static <T, U, V> BiFunction<T, U, Result> checkEquals(

--- a/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
+++ b/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
@@ -25,6 +25,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition;
 import com.radixdlt.atomos.CMAtomOS;
+import com.radixdlt.constraintmachine.WitnessData;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.atomos.Result;
@@ -275,5 +276,41 @@ public class TokensConstraintScryptTest {
 		when(staked.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
 		assertThat(staticCheck.apply(staked).getErrorMessage())
 			.contains("delegateAddress");
+	}
+
+	@Test
+	public void when_checking_signed_by_and_signed__result_has_no_error() {
+		WitnessData witnessData = mock(WitnessData.class);
+		RadixAddress address = mock(RadixAddress.class);
+		when(witnessData.isSignedBy(address.getPublicKey())).thenReturn(true);
+		assertThat(TokensConstraintScrypt.checkSignedBy(witnessData, address).isSuccess()).isTrue();
+	}
+
+	@Test
+	public void when_checking_signed_by_and_not_signed__result_has_error() {
+		WitnessData witnessData = mock(WitnessData.class);
+		RadixAddress address = mock(RadixAddress.class);
+		when(witnessData.isSignedBy(address.getPublicKey())).thenReturn(false);
+		assertThat(TokensConstraintScrypt.checkSignedBy(witnessData, address).isError()).isTrue();
+	}
+
+	@Test
+	public void when_checking_token_permission_allowed_and_allowed__result_has_no_error() {
+		WitnessData witnessData = mock(WitnessData.class);
+		TokenPermission tokenPermission = mock(TokenPermission.class);
+		RRI token = mock(RRI.class);
+		when(tokenPermission.check(token, witnessData)).thenReturn(Result.success());
+		assertThat(TokensConstraintScrypt.checkTokenActionAllowed(witnessData, tokenPermission, token)
+			.isSuccess()).isTrue();
+	}
+
+	@Test
+	public void when_checking_token_permission_allowed_and_not_allowed__result_has_error() {
+		WitnessData witnessData = mock(WitnessData.class);
+		TokenPermission tokenPermission = mock(TokenPermission.class);
+		RRI token = mock(RRI.class);
+		when(tokenPermission.check(token, witnessData)).thenReturn(Result.error(""));
+		assertThat(TokensConstraintScrypt.checkTokenActionAllowed(witnessData, tokenPermission, token)
+			.isError()).isTrue();
 	}
 }

--- a/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
+++ b/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
@@ -81,6 +81,22 @@ public class TokensConstraintScryptTest {
 	}
 
 	@Test
+	public void when_validating_fixed_token_class_particle_with_too_long_symbol__result_has_error() {
+		FixedSupplyTokenDefinitionParticle token = PowerMockito.mock(FixedSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), "TEEEEEEEEEEEEEEEEEEEEEEEEEEST"));
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("Symbol: invalid length");
+	}
+
+	@Test
+	public void when_validating_fixed_token_class_particle_with_too_short_symbol__result_has_error() {
+		FixedSupplyTokenDefinitionParticle token = PowerMockito.mock(FixedSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), ""));
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("Symbol: invalid length");
+	}
+
+	@Test
 	public void when_validating_token_class_particle_without_description__result_is_success() {
 		RadixAddress addr = RadixAddress.from("JH1P8f3znbyrDj8F4RWpix7hRkgxqHjdW2fNnKpR3v6ufXnknor");
 		ImmutableMap<MutableSupplyTokenDefinitionParticle.TokenTransition, TokenPermission> perms = ImmutableMap.of(
@@ -147,6 +163,26 @@ public class TokensConstraintScryptTest {
 			TokenTransition.MINT, TokenPermission.ALL,
 			TokenTransition.BURN, TokenPermission.ALL
 		));
+		when(token.getIconUrl()).thenReturn("this is not a url");
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("Icon: not a valid URL");
+	}
+
+	@Test
+	public void when_validating_fixed_token_class_particle_with_too_long_description__result_has_error() {
+		FixedSupplyTokenDefinitionParticle token = PowerMockito.mock(FixedSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), "TEST"));
+		when(token.getDescription()).thenReturn(
+			IntStream.range(0, TokenDefinitionUtils.MAX_DESCRIPTION_LENGTH + 1).mapToObj(i -> "c").collect(Collectors.joining()));
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("Description: invalid length");
+	}
+
+	@Test
+	public void when_validating_fixed_token_class_particle_with_invalid_icon_url__result_has_error() {
+		FixedSupplyTokenDefinitionParticle token = PowerMockito.mock(FixedSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(token.getDescription()).thenReturn("Hello");
 		when(token.getIconUrl()).thenReturn("this is not a url");
 		assertThat(staticCheck.apply(token).getErrorMessage())
 			.contains("Icon: not a valid URL");

--- a/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
+++ b/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
@@ -170,6 +170,15 @@ public class TokensConstraintScryptTest {
 	}
 
 	@Test
+	public void when_validating_staked_token_with_null_amount__result_has_error() {
+		StakedTokensParticle staked = mock(StakedTokensParticle.class);
+		when(staked.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(staked.getAmount()).thenReturn(null);
+		assertThat(staticCheck.apply(staked).getErrorMessage())
+			.contains("null");
+	}
+
+	@Test
 	public void when_validating_token_instance_with_zero_amount__result_has_error() {
 		TransferrableTokensParticle transferrableTokensParticle = mock(TransferrableTokensParticle.class);
 		when(transferrableTokensParticle.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
@@ -184,6 +193,16 @@ public class TokensConstraintScryptTest {
 		when(burnedTokensParticle.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
 		when(burnedTokensParticle.getAmount()).thenReturn(UInt256.ZERO);
 		assertThat(staticCheck.apply(burnedTokensParticle).getErrorMessage())
+			.contains("zero");
+	}
+
+	@Test
+	public void when_validating_staked_token_with_zero_amount__result_has_error() {
+		StakedTokensParticle stakedTokensParticle = mock(StakedTokensParticle.class);
+		when(stakedTokensParticle.getDelegateAddress()).thenReturn(mock(RadixAddress.class));
+		when(stakedTokensParticle.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(stakedTokensParticle.getAmount()).thenReturn(UInt256.ZERO);
+		assertThat(staticCheck.apply(stakedTokensParticle).getErrorMessage())
 			.contains("zero");
 	}
 
@@ -208,6 +227,17 @@ public class TokensConstraintScryptTest {
 	}
 
 	@Test
+	public void when_validating_staked_token_with_null_granularity__result_has_error() {
+		StakedTokensParticle staked = mock(StakedTokensParticle.class);
+		when(staked.getDelegateAddress()).thenReturn(mock(RadixAddress.class));
+		when(staked.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(staked.getAmount()).thenReturn(UInt256.ONE);
+		when(staked.getGranularity()).thenReturn(null);
+		assertThat(staticCheck.apply(staked).getErrorMessage())
+			.contains("granularity");
+	}
+
+	@Test
 	public void when_validating_unallocated_token_with_zero_granularity__result_has_error() {
 		UnallocatedTokensParticle unallocated = mock(UnallocatedTokensParticle.class);
 		when(unallocated.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
@@ -225,5 +255,25 @@ public class TokensConstraintScryptTest {
 		when(transferrableTokensParticle.getGranularity()).thenReturn(UInt256.TWO);
 		assertThat(staticCheck.apply(transferrableTokensParticle).getErrorMessage())
 			.contains("granularity");
+	}
+
+	@Test
+	public void when_validating_staked_token_with_zero_granularity__result_has_error() {
+		StakedTokensParticle staked = mock(StakedTokensParticle.class);
+		when(staked.getDelegateAddress()).thenReturn(mock(RadixAddress.class));
+		when(staked.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(staked.getAmount()).thenReturn(UInt256.ONE);
+		when(staked.getGranularity()).thenReturn(UInt256.ZERO);
+		assertThat(staticCheck.apply(staked).getErrorMessage())
+			.contains("granularity");
+	}
+
+	@Test
+	public void when_validating_staked_token_with_null_delegate_address__result_has_error() {
+		StakedTokensParticle staked = mock(StakedTokensParticle.class);
+		when(staked.getDelegateAddress()).thenReturn(null);
+		when(staked.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		assertThat(staticCheck.apply(staked).getErrorMessage())
+			.contains("delegateAddress");
 	}
 }

--- a/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
@@ -40,35 +40,35 @@ public class StakedTokensParticleSerializationTest extends SerializeObjectEngine
 	public static final ImmutableMap<MutableSupplyTokenDefinitionParticle.TokenTransition, TokenPermission> TOKEN_PERMISSIONS = ImmutableMap.of();
 
 	public StakedTokensParticleSerializationTest() {
-        super(StakedTokensParticle.class, StakedTokensParticleSerializationTest::get);
-    }
+		super(StakedTokensParticle.class, StakedTokensParticleSerializationTest::get);
+	}
 
-    @BeforeClass
-    public static void startStakedTokensParticleSerializationTest() {
-        TestSetupUtils.installBouncyCastleProvider();
-    }
+	@BeforeClass
+	public static void startStakedTokensParticleSerializationTest() {
+		TestSetupUtils.installBouncyCastleProvider();
+	}
 
-    @Test
-    public void testGetters() {
-    	StakedTokensParticle p = get();
-    	assertEquals(DELEGATE_ADDRESS, p.getDelegateAddress());
-    	assertEquals(ADDRESS, p.getAddress());
-	    assertEquals(AMOUNT, p.getAmount());
-	    assertEquals(GRANULARITY, p.getGranularity());
+	@Test
+	public void testGetters() {
+		StakedTokensParticle p = get();
+		assertEquals(DELEGATE_ADDRESS, p.getDelegateAddress());
+		assertEquals(ADDRESS, p.getAddress());
+		assertEquals(AMOUNT, p.getAmount());
+		assertEquals(GRANULARITY, p.getGranularity());
 		assertEquals(TOKEN, p.getTokDefRef());
 		assertEquals(PLANCK, p.getPlanck());
 		assertEquals(TOKEN_PERMISSIONS, p.getTokenPermissions());
-    }
+	}
 
-    private static StakedTokensParticle get() {
-    	return new StakedTokensParticle(
-		    DELEGATE_ADDRESS,
-		    ADDRESS,
-		    AMOUNT,
-		    GRANULARITY,
-		    TOKEN,
-		    PLANCK,
-		    TOKEN_PERMISSIONS
-	    );
-    }
+	private static StakedTokensParticle get() {
+		return new StakedTokensParticle(
+			DELEGATE_ADDRESS,
+			ADDRESS,
+			AMOUNT,
+			GRANULARITY,
+			TOKEN,
+			PLANCK,
+			TOKEN_PERMISSIONS
+		);
+	}
 }

--- a/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
@@ -25,7 +25,6 @@ import com.radixdlt.atommodel.tokens.TokenPermission;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.utils.UInt256;
-import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright 2020 Radix DLT Ltd
+ *
+ * Radix DLT Ltd licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package com.radixdlt.serialization;
+
+import com.google.common.collect.ImmutableMap;
+import com.radixdlt.TestSetupUtils;
+import com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle;
+import com.radixdlt.atommodel.tokens.StakedTokensParticle;
+import com.radixdlt.atommodel.tokens.TokenPermission;
+import com.radixdlt.identifiers.RRI;
+import com.radixdlt.identifiers.RadixAddress;
+import com.radixdlt.utils.UInt256;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StakedTokensParticleSerializationTest extends SerializeObjectEngine<StakedTokensParticle> {
+	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
+	public static final RadixAddress ADDRESS = RadixAddress.from("23B6fH3FekJeP6e5guhZAk6n9z4fmTo5Tngo3a11Wg5R8gsWTV2x");
+	public static final RRI TOKEN = RRI.of(ADDRESS, "COOKIE");
+	public static final UInt256 AMOUNT = UInt256.EIGHT;
+	public static final UInt256 GRANULARITY = UInt256.ONE;
+	public static final int PLANCK = 100;
+	public static final ImmutableMap<MutableSupplyTokenDefinitionParticle.TokenTransition, TokenPermission> TOKEN_PERMISSIONS = ImmutableMap.of();
+
+	public StakedTokensParticleSerializationTest() {
+        super(StakedTokensParticle.class, StakedTokensParticleSerializationTest::get);
+    }
+
+    @BeforeClass
+    public static void startStakedTokensParticleSerializationTest() {
+        TestSetupUtils.installBouncyCastleProvider();
+    }
+
+    @Test
+    public void testGetters() {
+    	StakedTokensParticle p = get();
+    	assertEquals(DELEGATE_ADDRESS, p.getDelegateAddress());
+    	assertEquals(ADDRESS, p.getAddress());
+	    assertEquals(AMOUNT, p.getAmount());
+	    assertEquals(GRANULARITY, p.getGranularity());
+		assertEquals(TOKEN, p.getTokDefRef());
+		assertEquals(PLANCK, p.getPlanck());
+		assertEquals(TOKEN_PERMISSIONS, p.getTokenPermissions());
+    }
+
+    private static StakedTokensParticle get() {
+    	return new StakedTokensParticle(
+		    DELEGATE_ADDRESS,
+		    ADDRESS,
+		    AMOUNT,
+		    GRANULARITY,
+		    TOKEN,
+		    PLANCK,
+		    TOKEN_PERMISSIONS
+	    );
+    }
+}

--- a/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
+++ b/src/test/java/com/radixdlt/serialization/StakedTokensParticleSerializationTest.java
@@ -25,10 +25,14 @@ import com.radixdlt.atommodel.tokens.TokenPermission;
 import com.radixdlt.identifiers.RRI;
 import com.radixdlt.identifiers.RadixAddress;
 import com.radixdlt.utils.UInt256;
+import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static com.radixdlt.atommodel.tokens.MutableSupplyTokenDefinitionParticle.TokenTransition.MINT;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class StakedTokensParticleSerializationTest extends SerializeObjectEngine<StakedTokensParticle> {
 	public static final RadixAddress DELEGATE_ADDRESS = RadixAddress.from("JEbhKQzBn4qJzWJFBbaPioA2GTeaQhuUjYWkanTE6N8VvvPpvM8");
@@ -58,6 +62,16 @@ public class StakedTokensParticleSerializationTest extends SerializeObjectEngine
 		assertEquals(TOKEN, p.getTokDefRef());
 		assertEquals(PLANCK, p.getPlanck());
 		assertEquals(TOKEN_PERMISSIONS, p.getTokenPermissions());
+		assertEquals(TOKEN_PERMISSIONS.get(MINT), p.getTokenPermission(MINT));
+	}
+
+	@Test
+	public void testToString() {
+		StakedTokensParticle p = get();
+		String str = p.toString();
+		assertThat(str, containsString(p.getAddress().toString()));
+		assertThat(str, containsString(p.getAmount().toString()));
+		assertThat(str, containsString(p.getDelegateAddress().toString()));
 	}
 
 	private static StakedTokensParticle get() {


### PR DESCRIPTION
Adds support for basic delegated staking by introducing a new `StakedTokensParticle` state for instantiated tokens. Specifically, this adds transitions as described [in our design](https://radixdlt.atlassian.net/wiki/spaces/RPNV1/pages/851640333/Proof+Of+Stake+v1):
- Stake owned tokens to a delegate (`Transferrable` -> `Staked`)
- Redelegate staked tokens from a delegate to another delegate (`Staked` -> `Staked`)
- Unstake staked tokens from a delegate (`Staked` -> `Transferrable`)
Of course, all the usable fungible/ownable constraints apply. 