### PR TITLE
Add generic `url` to token definitions

### DIFF
--- a/src/main/java/com/radixdlt/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/FixedSupplyTokenDefinitionParticle.java
@@ -56,6 +56,10 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle {
 	@DsonOutput(Output.ALL)
 	private String iconUrl;
 
+	@JsonProperty("url")
+	@DsonOutput(Output.ALL)
+	private String url;
+
 	FixedSupplyTokenDefinitionParticle() {
 		// For serializer only
 		super();
@@ -67,7 +71,8 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle {
 		String description,
 		UInt256 supply,
 		UInt256 granularity,
-		String iconUrl
+		String iconUrl,
+		String url
 	) {
 		super(rri.getAddress().euid());
 
@@ -77,6 +82,7 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle {
 		this.supply = Objects.requireNonNull(supply);
 		this.granularity = Objects.requireNonNull(granularity);
 		this.iconUrl = iconUrl;
+		this.url = url;
 	}
 
 	public RRI getRRI() {
@@ -101,6 +107,10 @@ public final class FixedSupplyTokenDefinitionParticle extends Particle {
 
 	public String getIconUrl() {
 		return this.iconUrl;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 
 	@Override

--- a/src/main/java/com/radixdlt/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/MutableSupplyTokenDefinitionParticle.java
@@ -60,6 +60,10 @@ public final class MutableSupplyTokenDefinitionParticle extends Particle {
 	@DsonOutput(DsonOutput.Output.ALL)
 	private String iconUrl;
 
+	@JsonProperty("url")
+	@DsonOutput(Output.ALL)
+	private String url;
+
 	private Map<TokenTransition, TokenPermission> tokenPermissions;
 
 	MutableSupplyTokenDefinitionParticle() {
@@ -74,6 +78,7 @@ public final class MutableSupplyTokenDefinitionParticle extends Particle {
 		String description,
 		UInt256 granularity,
 		String iconUrl,
+		String url,
 		Map<TokenTransition, TokenPermission> tokenPermissions
 	) {
 		super(address.euid());
@@ -83,6 +88,7 @@ public final class MutableSupplyTokenDefinitionParticle extends Particle {
 		this.description = description;
 		this.granularity = Objects.requireNonNull(granularity);
 		this.iconUrl = iconUrl;
+		this.url = url;
 		this.tokenPermissions = ImmutableMap.copyOf(tokenPermissions);
 
 		if (this.tokenPermissions.keySet().size() != TokenTransition.values().length) {
@@ -121,6 +127,10 @@ public final class MutableSupplyTokenDefinitionParticle extends Particle {
 
 	public String getIconUrl() {
 		return this.iconUrl;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 
 	@JsonProperty("permissions")

--- a/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
@@ -214,6 +214,11 @@ public final class TokenDefinitionUtils {
 			return iconResult;
 		}
 
+		final Result urlResult = validateUrl(tokenDefParticle.getUrl());
+		if (urlResult.isError()) {
+			return urlResult;
+		}
+
 		return Result.success();
 	}
 }

--- a/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
+++ b/src/main/java/com/radixdlt/atommodel/tokens/TokenDefinitionUtils.java
@@ -66,6 +66,13 @@ public final class TokenDefinitionUtils {
 		return "XRD";
 	}
 
+	private static Result validateUrl(String url) {
+		if (url != null && !OWASP_URL_REGEX.matcher(url).matches()) {
+			return Result.error("URL: not a valid URL: " + url);
+		}
+		return Result.success();
+	}
+
 	private static Result validateIconUrl(String iconUrl) {
 		if (iconUrl != null && !OWASP_URL_REGEX.matcher(iconUrl).matches()) {
 			return Result.error("Icon: not a valid URL: " + iconUrl);
@@ -168,6 +175,11 @@ public final class TokenDefinitionUtils {
 		final Result iconResult = validateIconUrl(tokenDefParticle.getIconUrl());
 		if (iconResult.isError()) {
 			return iconResult;
+		}
+
+		final Result urlResult = validateUrl(tokenDefParticle.getUrl());
+		if (urlResult.isError()) {
+			return urlResult;
 		}
 
 		return Result.success();

--- a/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
+++ b/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
@@ -189,6 +189,16 @@ public class TokensConstraintScryptTest {
 	}
 
 	@Test
+	public void when_validating_fixed_token_class_particle_with_invalid_url__result_has_error() {
+		FixedSupplyTokenDefinitionParticle token = PowerMockito.mock(FixedSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(token.getDescription()).thenReturn("Hello");
+		when(token.getUrl()).thenReturn("this is not a url");
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("not a valid URL");
+	}
+
+	@Test
 	public void when_validating_token_instance_with_null_amount__result_has_error() {
 		TransferrableTokensParticle transferrableTokensParticle = mock(TransferrableTokensParticle.class);
 		when(transferrableTokensParticle.getTokDefRef()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));

--- a/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
+++ b/src/test/java/com/radixdlt/atommodel/tokens/TokensConstraintScryptTest.java
@@ -110,6 +110,7 @@ public class TokensConstraintScryptTest {
 			null,
 			UInt256.ONE,
 			null,
+			null,
 			perms
 		);
 		assertTrue(staticCheck.apply(token).isSuccess());
@@ -128,6 +129,7 @@ public class TokensConstraintScryptTest {
 			"",
 			"",
 			UInt256.ONE,
+			null,
 			null,
 			perms
 		);
@@ -166,6 +168,20 @@ public class TokensConstraintScryptTest {
 		when(token.getIconUrl()).thenReturn("this is not a url");
 		assertThat(staticCheck.apply(token).getErrorMessage())
 			.contains("Icon: not a valid URL");
+	}
+
+	@Test
+	public void when_validating_token_class_particle_with_invalid_url__result_has_error() {
+		MutableSupplyTokenDefinitionParticle token = PowerMockito.mock(MutableSupplyTokenDefinitionParticle.class);
+		when(token.getRRI()).thenReturn(RRI.of(mock(RadixAddress.class), "TOK"));
+		when(token.getDescription()).thenReturn("Hello");
+		when(token.getTokenPermissions()).thenReturn(ImmutableMap.of(
+			TokenTransition.MINT, TokenPermission.ALL,
+			TokenTransition.BURN, TokenPermission.ALL
+		));
+		when(token.getUrl()).thenReturn("this is not a url");
+		assertThat(staticCheck.apply(token).getErrorMessage())
+			.contains("not a valid URL");
 	}
 
 	@Test


### PR DESCRIPTION
Adds a generic, optional `url` field to both fixed and mutable supply token definitions. 